### PR TITLE
web: Gapfill History Window Intervals

### DIFF
--- a/src/Interface/Web/src/lib/api.ts
+++ b/src/Interface/Web/src/lib/api.ts
@@ -133,13 +133,23 @@ export class TTXClient {
     }
 
     /**
+     * @param step (optional) 
+     * @param after (optional) 
      * @return OK
      */
-    getCreator(slug: string): Promise<CreatorDto> {
-        let url_ = this.baseUrl + "/creators/{slug}";
+    getCreator(slug: string, step?: TimeStep | undefined, after?: Date | undefined): Promise<CreatorDto> {
+        let url_ = this.baseUrl + "/creators/{slug}?";
         if (slug === undefined || slug === null)
             throw new Error("The parameter 'slug' must be defined.");
         url_ = url_.replace("{slug}", encodeURIComponent("" + slug));
+        if (step === null)
+            throw new Error("The parameter 'step' cannot be null.");
+        else if (step !== undefined)
+            url_ += "step=" + encodeURIComponent("" + step) + "&";
+        if (after === null)
+            throw new Error("The parameter 'after' cannot be null.");
+        else if (after !== undefined)
+            url_ += "after=" + encodeURIComponent(after ? "" + after.toISOString() : "") + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: RequestInit = {

--- a/src/Interface/Web/src/routes/channels/[channelname]/+page.server.ts
+++ b/src/Interface/Web/src/routes/channels/[channelname]/+page.server.ts
@@ -4,7 +4,7 @@ import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types.js';
 import { CreatorDto, CreatorShareDto, CreatorTransactionDto, TimeStep } from '$lib/api.js';
 
-export type Interval = 'all' | '24h' | '12h' | '6h' | '1h'
+export type Interval = '24h' | '12h' | '6h' | '1h'
 
 export const load: PageServerLoad = async ({ cookies, params, url }) => {
 	try {
@@ -20,7 +20,7 @@ export const load: PageServerLoad = async ({ cookies, params, url }) => {
 		);
 
 		return {
-			creator: creator.toJSON(),
+			creator: creator.toJSON() as CreatorDto,
 			shares: creator.shares.map((d) => d.toJSON() as CreatorShareDto),
 			transactions: creator.transactions.map((d) => d.toJSON() as CreatorTransactionDto),
 			interval

--- a/src/Interface/Web/src/routes/channels/[channelname]/+page.server.ts
+++ b/src/Interface/Web/src/routes/channels/[channelname]/+page.server.ts
@@ -10,22 +10,17 @@ export const load: PageServerLoad = async ({ cookies, params, url }) => {
 	try {
 		const channelSlug = params.channelname.toLowerCase();
 		const interval = (url.searchParams.get('interval') || '1h') as Interval;
+		const hours = interval === 'all' ? 1000000 : interval === '24h' ? 24 : interval === '12h' ? 12 : interval === '6h' ? 6 : 1;
 
 		const token = getToken(cookies);
 		const client = getApiClient(token || '');
-		const creator = await client.getCreator(channelSlug);
-
-		const hours = interval === 'all' ? 1000000 : interval === '24h' ? 24 : interval === '12h' ? 12 : interval === '6h' ? 6 : 1;
-
-
-		const shareHistory = await client.getLatestCreatorValue(channelSlug, new Date(Date.now() - hours * 60 * 60 * 1000), TimeStep.Minute);
-
+		const creator = await client.getCreator(channelSlug,
+			TimeStep.Minute,
+			new Date(Date.now() - hours * 60 * 60 * 1000)
+		);
 
 		return {
-			creator: {
-				...creator.toJSON(),
-				history: shareHistory.map((d) => d.toJSON())
-			} as CreatorDto,
+			creator: creator.toJSON(),
 			shares: creator.shares.map((d) => d.toJSON() as CreatorShareDto),
 			transactions: creator.transactions.map((d) => d.toJSON() as CreatorTransactionDto),
 			interval

--- a/src/Interface/Web/src/routes/channels/[channelname]/+page.server.ts
+++ b/src/Interface/Web/src/routes/channels/[channelname]/+page.server.ts
@@ -10,7 +10,7 @@ export const load: PageServerLoad = async ({ cookies, params, url }) => {
 	try {
 		const channelSlug = params.channelname.toLowerCase();
 		const interval = (url.searchParams.get('interval') || '1h') as Interval;
-		const hours = interval === 'all' ? 1000000 : interval === '24h' ? 24 : interval === '12h' ? 12 : interval === '6h' ? 6 : 1;
+		const hours = interval === '24h' ? 24 : interval === '12h' ? 12 : interval === '6h' ? 6 : 1;
 
 		const token = getToken(cookies);
 		const client = getApiClient(token || '');

--- a/src/Interface/Web/src/routes/channels/[channelname]/+page.svelte
+++ b/src/Interface/Web/src/routes/channels/[channelname]/+page.svelte
@@ -9,14 +9,13 @@
 	import { TimeStep, TransactionAction, Vote } from '$lib/api';
 	import { addRecentStreamer } from '$lib/utils/recentStreamers';
 	import type { PageProps } from './$types';
-	import { page } from '$app/state';
 
 	let { data }: PageProps = $props();
 	let creator = $state(data.creator);
 
 	let history = $state<Vote[]>(data.creator.history);
 	let buySellModal: TransactionAction | null = $state(null);
-	let pullTask: NodeJS.Timeout | null = null;
+	let pullTask: number | null = $state(null);
 	let interval = $state(data.interval);
 	function setModal(modal: TransactionAction) {
 		buySellModal = modal;

--- a/src/Interface/Web/src/routes/channels/[channelname]/IntervalSelector.svelte
+++ b/src/Interface/Web/src/routes/channels/[channelname]/IntervalSelector.svelte
@@ -5,7 +5,6 @@
 	const { interval }: { interval: Interval } = $props();
 
 	const intervals: { label: string; value: Interval }[] = [
-		{ label: 'All', value: 'all' },
 		{ label: '24h', value: '24h' },
 		{ label: '12h', value: '12h' },
 		{ label: '6h', value: '6h' },


### PR DESCRIPTION
https://github.com/user-attachments/assets/068c6822-0d3a-4bf0-80aa-9cc47fdadeb4

---

- Passed the history params into `getCreator` since that will gapfill missing data points.
- Removed `all` selector since it's too much data, we can bring it back later once we have set windows / projections people can select through. ie "one month," "one week," etc.
- Updated type of `pullTask` to number instead of `NodeJS.Timeout`