### PR TITLE
Autofocus search added

### DIFF
--- a/src/TTX.Web/routes/(_islands)/Search.tsx
+++ b/src/TTX.Web/routes/(_islands)/Search.tsx
@@ -115,11 +115,10 @@ export default function SearchModal({ state, isSearchOpen }: { state: State, isS
           <div class="join flex">
             <input
               type="text"
-              ref={(el) => {
-                if (el) {
+              ref={(self) => {
+                if (self) {
                   requestAnimationFrame(() => {
-                    console.log("hi");
-                    el.focus();
+                    self.focus();
                   });
                 }
               }}


### PR DESCRIPTION
When user opens search modal on home page, the input element is now autofocused so they can type right away.